### PR TITLE
:boom: fix: lang parameter not defined in 404 NavBar

### DIFF
--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -13,5 +13,3 @@ export let i18n: object = {
 
 export const languages: Array<string> = Object.keys(i18n);
 export const defaultLang = "en" as keyof typeof i18n;
-
-console.log(languages);

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,7 +1,8 @@
 ---
-
 import "../styles/global.css";
 import NavBar from "../components/NavBar.astro";
+
+Astro.params.lang = "en";
 ---
 
 <!DOCTYPE html>


### PR DESCRIPTION
Fixed `Astro.param.lang` not defined in 404 page.
Fix: manually defined language to English/`en`.